### PR TITLE
LIBSEARCH-159. Modified search term encoding

### DIFF
--- a/app/searchers/quick_search/ebsco_discovery_service_api_article_searcher.rb
+++ b/app/searchers/quick_search/ebsco_discovery_service_api_article_searcher.rb
@@ -3,7 +3,6 @@
 module QuickSearch
   # QuickSearch seacher for WorldCat
   class EbscoDiscoveryServiceApiArticleSearcher < EbscoDiscoveryServiceApiSearcher
-
     def query_params
       article_filter = { 'eds_publication_type_facet' => ['Academic Journals'] }
       {
@@ -15,7 +14,7 @@ module QuickSearch
 
     def item_link(record)
       return get_config('doi_link') + record.eds_document_doi if record.eds_document_doi
-      get_config('url_link') + "&db=" + record.eds_database_id + "&AN=" + record.eds_accession_number
+      get_config('url_link') + '&db=' + record.eds_database_id + '&AN=' + record.eds_accession_number
     end
 
     def items_per_page

--- a/app/searchers/quick_search/ebsco_discovery_service_api_article_searcher.rb
+++ b/app/searchers/quick_search/ebsco_discovery_service_api_article_searcher.rb
@@ -18,14 +18,6 @@ module QuickSearch
       get_config('url_link') + "&db=" + record.eds_database_id + "&AN=" + record.eds_accession_number
     end
 
-    # Returns the sanitized search query entered by the user, skipping
-    # the default QuickSearch query filtering
-    def sanitized_user_search_query
-      # Need to use "to_str" as otherwise Japanese text isn't returned
-      # properly
-      sanitize(@q).to_str
-    end
-
     def items_per_page
       allowed_values = [10, 25, 50, 100]
       allowed_values.each do |val|

--- a/app/searchers/quick_search/ebsco_discovery_service_api_searcher.rb
+++ b/app/searchers/quick_search/ebsco_discovery_service_api_searcher.rb
@@ -2,7 +2,7 @@
 
 module QuickSearch
   # QuickSearch seacher for WorldCat
-  class EbscoDiscoveryServiceApiSearcher < QuickSearch::Searcher 
+  class EbscoDiscoveryServiceApiSearcher < QuickSearch::Searcher
 
     def session
       return @eds_session if @eds_session
@@ -43,11 +43,17 @@ module QuickSearch
     end
 
     def loaded_link
-      get_config('loaded_link') + sanitized_user_search_query
+      get_config('loaded_link') + percent_encoded_raw_user_search_query
     end
 
     def item_link(record)
       get_config('url_link') + "&db=" + record.eds_database_id + "&AN=" + record.eds_accession_number
+    end
+
+    # Returns the percent-encoded search query entered by the user, skipping
+    # the default QuickSearch query filtering
+    def percent_encoded_raw_user_search_query
+      CGI.escape(@q)
     end
 
     # Returns the sanitized search query entered by the user, skipping
@@ -55,7 +61,7 @@ module QuickSearch
     def sanitized_user_search_query
       # Need to use "to_str" as otherwise Japanese text isn't returned
       # properly
-      sanitize(@q).to_str.downcase 
+      sanitize(@q).to_str
     end
 
     def items_per_page

--- a/app/searchers/quick_search/ebsco_discovery_service_api_searcher.rb
+++ b/app/searchers/quick_search/ebsco_discovery_service_api_searcher.rb
@@ -3,13 +3,12 @@
 module QuickSearch
   # QuickSearch seacher for WorldCat
   class EbscoDiscoveryServiceApiSearcher < QuickSearch::Searcher
-
     def session
       return @eds_session if @eds_session
       # Get the configuration values
       username = get_config('username')
       password = get_config('password')
-      @eds_session = EBSCO::EDS::Session.new({user: username, pass: password, profile: 'edsapi', guest: false})
+      @eds_session = EBSCO::EDS::Session.new(user: username, pass: password, profile: 'edsapi', guest: false)
       @eds_session
     end
 
@@ -47,7 +46,7 @@ module QuickSearch
     end
 
     def item_link(record)
-      get_config('url_link') + "&db=" + record.eds_database_id + "&AN=" + record.eds_accession_number
+      get_config('url_link') + '&db=' + record.eds_database_id + '&AN=' + record.eds_accession_number
     end
 
     # Returns the percent-encoded search query entered by the user, skipping

--- a/quick_search-ebsco_discovery_service_api_searcher.gemspec
+++ b/quick_search-ebsco_discovery_service_api_searcher.gemspec
@@ -18,8 +18,8 @@ Gem::Specification.new do |s|
 
   s.files = Dir['{app,config,db,lib}/**/*', 'LICENSE', 'Rakefile', 'README.md']
 
-  s.add_dependency 'quick_search-core', '~> 0'
   s.add_dependency 'ebsco-eds', '~> 1.0.7'
+  s.add_dependency 'quick_search-core', '~> 0'
   s.add_development_dependency 'rubocop', '= 0.52.1'
   # sqlite3 loaded for testing with the "dummy" application
   s.add_development_dependency 'sqlite3'


### PR DESCRIPTION
Modified search term encoding so that search terms with double quotes and spaces would
be correctly encoded when displayed in the loaded_link

https://issues.umd.edu/browse/LIBSEARCH-159