### PR TITLE
LIBSEARCH-162. Added item formats to EBSCO searcher

### DIFF
--- a/app/searchers/quick_search/ebsco_discovery_service_api_article_searcher.rb
+++ b/app/searchers/quick_search/ebsco_discovery_service_api_article_searcher.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module QuickSearch
-  # QuickSearch seacher for WorldCat
+  # QuickSearch seacher for EBSCO Discovery Service (Articles)
   class EbscoDiscoveryServiceApiArticleSearcher < EbscoDiscoveryServiceApiSearcher
     def query_params
       article_filter = { 'eds_publication_type_facet' => ['Academic Journals'] }


### PR DESCRIPTION
Added "item_format" field to JSON returned by the EBSCO searcher.

Added "ItemFormats" class to map EBSCO publication types to UMD formats.

https://issues.umd.edu/browse/LIBSEARCH-162