### PR TITLE
LIBSEARCH-165. Changed "ItemFormats" class to "EbscoItemFormats"

### DIFF
--- a/app/searchers/quick_search/ebsco_discovery_service_api_searcher.rb
+++ b/app/searchers/quick_search/ebsco_discovery_service_api_searcher.rb
@@ -34,7 +34,7 @@ module QuickSearch
     # Returns the item format for the given record. Using a method so
     # it can be overridden by subclasses.
     def item_format(record)
-      ItemFormats.item_format(record)
+      EbscoItemFormats.item_format(record)
     end
 
     def total
@@ -84,7 +84,7 @@ module QuickSearch
   end
 
   # Provides a mapping of EBSCO publication_type_ids to UMD types
-  class ItemFormats
+  class EbscoItemFormats
     # Map of EBSCO publication_types ids to UMD format, i.e.
     # EBSCO => UMD
     @item_formats = {


### PR DESCRIPTION
Changed name of "ItemFormats" class to be unique, so that it would
not conflict with the "ItemFormats" class in the WorldCat Discovery
searcher.

https://issues.umd.edu/browse/LIBSEARCH-165