### PR TITLE
LIBSEARCH-167. Mapped "academicJournal" publication type to "article"

### DIFF
--- a/app/searchers/quick_search/ebsco_discovery_service_api_searcher.rb
+++ b/app/searchers/quick_search/ebsco_discovery_service_api_searcher.rb
@@ -88,12 +88,13 @@ module QuickSearch
     # Map of EBSCO publication_types ids to UMD format, i.e.
     # EBSCO => UMD
     @item_formats = {
+      'academicJournal' => 'article',
       'audio' => 'audio',
       'book' => 'book',
       'ebook' => 'e_book',
       'image' => 'image',
-      'serialPeriodical' => 'journal',
       'journal' => 'journal',
+      'serialPeriodical' => 'journal',
       'map' => 'map',
       'score' => 'score',
       'dissertation' => 'thesis',


### PR DESCRIPTION
Map the EBSCO publication type id of "academicJournal" to the UMD
"article" format.

It seems odd that EBSCO's "academicJournal" type are really articles,
but it is clear from the search results that these are articles, so
using that designation until we get better information from EBSCO.

https://issues.umd.edu/browse/LIBSEARCH-167